### PR TITLE
Created rosinstall file for ada demo

### DIFF
--- a/ada-demo.rosinstall
+++ b/ada-demo.rosinstall
@@ -11,5 +11,5 @@
 - git: {local-name: or_parabolicsmoother, uri: 'https://github.com/personalrobotics/or_parabolicsmoother.git'}
 - git: {local-name: mico_hardware, uri: 'https://github.com/personalrobotics/mico_hardware.git'}
 - git: {local-name: pr_control_msgs, uri: 'https://github.com/personalrobotics/pr_control_msgs.git'}
-- git: {local-name: ada_meal_scenario, uri 'https://github.com/personalrobotics/ada_meal_scenario.git'}
-- git: {local-name: morsel, uri 'https://github.com/personalrobotics/morsel.git'}
+- git: {local-name: ada_meal_scenario, uri: 'https://github.com/personalrobotics/ada_meal_scenario.git'}
+- git: {local-name: morsel, uri: 'https://github.com/personalrobotics/morsel.git'}

--- a/ada-demo.rosinstall
+++ b/ada-demo.rosinstall
@@ -1,0 +1,15 @@
+- git: {local-name: openrave_catkin, uri: 'https://github.com/personalrobotics/openrave_catkin.git'}
+- git: {local-name: comps, uri: 'https://github.com/personalrobotics/comps.git'}
+- git: {local-name: prpy, uri: 'https://github.com/personalrobotics/prpy.git'}
+- git: {local-name: or_rviz, uri: 'https://github.com/personalrobotics/or_rviz.git'}
+- git: {local-name: or_ompl, uri: 'https://github.com/personalrobotics/or_ompl.git'}
+- git: {local-name: ada, uri: 'https://github.com/personalrobotics/ada.git'}
+- git: {local-name: or_trac_ik, uri: 'https://github.com/personalrobotics/or_trac_ik.git'}
+- git: {local-name: or_urdf, uri: 'https://github.com/personalrobotics/or_urdf.git'}
+- git: {local-name: pr-ordata, uri: 'https://github.com/personalrobotics/pr-ordata.git'}
+- git: {local-name: pr_ros_controllers, uri: 'https://github.com/personalrobotics/pr_ros_controllers.git'}
+- git: {local-name: or_parabolicsmoother, uri: 'https://github.com/personalrobotics/or_parabolicsmoother.git'}
+- git: {local-name: mico_hardware, uri: 'https://github.com/personalrobotics/mico_hardware.git'}
+- git: {local-name: pr_control_msgs, uri: 'https://github.com/personalrobotics/pr_control_msgs.git'}
+- git: {local-name: ada_meal_scenario, uri 'https://github.com/personalrobotics/ada_meal_scenario.git'}
+- git: {local-name: morsel, uri 'https://github.com/personalrobotics/morsel.git'}


### PR DESCRIPTION
This uses more than just the basic Ada packages, so it would be nice to have a single rosinstall file to get all of the packages needed to run the demo. The version history is tangled, but I really just added two lines at the end of the usual ada.rosinstall file and called it ada-demo.rosinstall.