### PR TITLE
Switch herb-minimal-sim.rosinstall to Aikido stack

### DIFF
--- a/herb-minimal-sim.rosinstall
+++ b/herb-minimal-sim.rosinstall
@@ -1,14 +1,6 @@
-- git: {local-name: herbpy, uri: 'https://github.com/personalrobotics/herbpy'}
-- git: {local-name: prpy, uri: 'https://github.com/personalrobotics/prpy'}
+# This .rosinstall file is indented to be used for projects that simulate HERB such as pantry-loading.
+- git: {local-name: pr_tsr, uri: 'https://github.com/personalrobotics/pr_tsr.git'}
+- git: {local-name: pr_ordata, uri: 'https://github.com/personalrobotics/pr-ordata.git'}
+- git: {local-name: libherb, uri: 'https://github.com/personalrobotics/libherb'}
 - git: {local-name: herb_description, uri: 'https://github.com/personalrobotics/herb_description'}
-- git: {local-name: openrave_catkin, uri: 'https://github.com/personalrobotics/openrave_catkin'}
-- git: {local-name: or_parabolicsmoother, uri: 'https://github.com/personalrobotics/or_parabolicsmoother'}
-- git: {local-name: or_trajopt, uri: 'https://github.com/personalrobotics/or_trajopt'}
-- git: {local-name: or_cdchomp, uri: 'https://github.com/personalrobotics/or_cdchomp'}
-- git: {local-name: or_urdf, uri: 'https://github.com/personalrobotics/or_urdf'}
-- git: {local-name: or_rviz, uri: 'https://github.com/personalrobotics/or_rviz'}
-- git: {local-name: or_fcl, uri: 'https://github.com/personalrobotics/or_fcl'}
-- git: {local-name: or_ompl, uri: 'https://github.com/personalrobotics/or_ompl'}
-- git: {local-name: or_sbpl, uri: 'https://github.com/personalrobotics/or_sbpl'}
-- git: {local-name: comps, uri: 'https://github.com/personalrobotics/comps'}
-- git: {local-name: tsr, uri: 'https://github.com/personalrobotics/tsr.git'}
+- git: {local-name: aikido, uri: 'https://github.com/personalrobotics/aikido'}


### PR DESCRIPTION
I could successfully build `pantry-loading` with this updated `herb-minimal-sim.rosinstall`.

This resolves https://trello.com/c/Gda2JcJS.

Question: do we need to keep the old `.rosinstall` files that use `prpy` stack like in a different branch or a subdirectory?