### PR TITLE
Adding missing packages for herb-minimal-sim workspace

### DIFF
--- a/herb-minimal-sim.rosinstall
+++ b/herb-minimal-sim.rosinstall
@@ -5,3 +5,6 @@
 - git: {local-name: libherb, uri: 'https://github.com/personalrobotics/libherb'}
 - git: {local-name: herb_description, uri: 'https://github.com/personalrobotics/herb_description'}
 - git: {local-name: aikido, uri: 'https://github.com/personalrobotics/aikido'}
+- git: {local-name: pr_control_msgs, uri: 'https://github.com/personalrobotics/pr_control_msgs.git'}
+- git: {local-name: schunk_neck, uri: 'https://github.com/personalrobotics/schunk_neck.git'}
+- git: {local-name: talker, uri: 'https://github.com/personalrobotics/talker.git'}


### PR DESCRIPTION
The herb-minimal-sim rosinstall seemed to be missing a few packages that aikido and libherb needed to compile. 