### PR TITLE
Update package name of DART

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7,7 +7,7 @@ clang-format-3.8:
   ubuntu: [clang-format-3.8]
   osx:
     homebrew: [clang-format@3.8]
-dart:
+dartsim:
   ubuntu: [libdart6-all-dev]
   osx:
     homebrew: [dartsim/dart/dartsim6]


### PR DESCRIPTION
[The ROS package name of DART was changed to `dartsim`](https://github.com/dartsim/dart/pull/1027).