### PR TITLE
pr-control-msgs required for libada

### DIFF
--- a/ada-feeding-sim.rosinstall
+++ b/ada-feeding-sim.rosinstall
@@ -6,4 +6,5 @@
 - git: {local-name: libada, uri: 'https://github.com/personalrobotics/libada.git', version: 'master'}
 - git: {local-name: pose_estimators, uri: 'https://github.com/personalrobotics/pose_estimators.git', version: 'demo/summer2019'}
 - git: {local-name: pr_assets, uri: 'https://github.com/personalrobotics/pr_assets.git', version: 'master'}
+- git: {local-name: pr_control_msgs, uri: 'https://github.com/personalrobotics/pr_control_msgs.git', version: 'master'}
 - git: {local-name: pr_tsr, uri: 'https://github.com/personalrobotics/pr_tsr.git', version: 'master'}


### PR DESCRIPTION
This is true even for simulation-only.

What it says on the tin. Small update.