### PR TITLE
Replaced references to old branches that were merged into master

### DIFF
--- a/ada-feeding-sim.rosinstall
+++ b/ada-feeding-sim.rosinstall
@@ -1,4 +1,4 @@
-- git: {local-name: ada_demos, uri: 'https://github.com/personalrobotics/ada_demos.git', version: 'master'}
+- git: {local-name: ada_feeding, uri: 'https://github.com/personalrobotics/ada_feeding.git', version: 'master'}
 - git: {local-name: ada_description, uri: 'https://github.com/personalrobotics/ada_description.git', version: 'master'}
 - git: {local-name: ada_launch, uri: 'https://github.com/personalrobotics/ada_launch.git', version: 'master'}
 - git: {local-name: aikido, uri: 'https://github.com/personalrobotics/aikido.git', version: 'master'}

--- a/ada-feeding-sim.rosinstall
+++ b/ada-feeding-sim.rosinstall
@@ -4,7 +4,7 @@
 - git: {local-name: aikido, uri: 'https://github.com/personalrobotics/aikido.git', version: 'master'}
 - git: {local-name: food_detector, uri: 'https://github.com/personalrobotics/food_detector.git', version: 'demo/summer2019'}
 - git: {local-name: libada, uri: 'https://github.com/personalrobotics/libada.git', version: 'master'}
-- git: {local-name: pose_estimators, uri: 'https://github.com/personalrobotics/pose_estimators.git', version: 'demo/summer2019'}
+- git: {local-name: pose_estimators, uri: 'https://github.com/personalrobotics/pose_estimators.git', version: 'master'}
 - git: {local-name: pr_assets, uri: 'https://github.com/personalrobotics/pr_assets.git', version: 'master'}
 - git: {local-name: pr_control_msgs, uri: 'https://github.com/personalrobotics/pr_control_msgs.git', version: 'master'}
 - git: {local-name: pr_tsr, uri: 'https://github.com/personalrobotics/pr_tsr.git', version: 'master'}

--- a/ada-feeding-sim.rosinstall
+++ b/ada-feeding-sim.rosinstall
@@ -1,8 +1,8 @@
-- git: {local-name: ada_feeding, uri: 'https://github.com/personalrobotics/ada_feeding.git', version: 'master'}
+- git: {local-name: ada_feeding, uri: 'https://github.com/personalrobotics/ada_feeding.git', version: 'main'}
 - git: {local-name: ada_description, uri: 'https://github.com/personalrobotics/ada_description.git', version: 'master'}
 - git: {local-name: ada_launch, uri: 'https://github.com/personalrobotics/ada_launch.git', version: 'master'}
 - git: {local-name: aikido, uri: 'https://github.com/personalrobotics/aikido.git', version: 'master'}
-- git: {local-name: food_detector, uri: 'https://github.com/personalrobotics/food_detector.git', version: 'demo/summer2019'}
+- git: {local-name: food_detector, uri: 'https://github.com/personalrobotics/food_detector.git', version: 'master'}
 - git: {local-name: libada, uri: 'https://github.com/personalrobotics/libada.git', version: 'master'}
 - git: {local-name: pose_estimators, uri: 'https://github.com/personalrobotics/pose_estimators.git', version: 'master'}
 - git: {local-name: pr_assets, uri: 'https://github.com/personalrobotics/pr_assets.git', version: 'master'}

--- a/ada-feeding.rosinstall
+++ b/ada-feeding.rosinstall
@@ -1,4 +1,4 @@
-- git: {local-name: ada_demos, uri: 'https://github.com/personalrobotics/ada_demos.git', version: 'master'}
+- git: {local-name: ada_feeding, uri: 'https://github.com/personalrobotics/ada_feeding.git', version: 'master'}
 - git: {local-name: ada_description, uri: 'https://github.com/personalrobotics/ada_description.git', version: 'master'}
 - git: {local-name: ada_launch, uri: 'https://github.com/personalrobotics/ada_launch.git', version: 'master'}
 - git: {local-name: aikido, uri: 'https://github.com/personalrobotics/aikido.git', version: 'master'}

--- a/ada-feeding.rosinstall
+++ b/ada-feeding.rosinstall
@@ -1,10 +1,10 @@
-- git: {local-name: ada_feeding, uri: 'https://github.com/personalrobotics/ada_feeding.git', version: 'master'}
+- git: {local-name: ada_feeding, uri: 'https://github.com/personalrobotics/ada_feeding.git', version: 'main'}
 - git: {local-name: ada_description, uri: 'https://github.com/personalrobotics/ada_description.git', version: 'master'}
 - git: {local-name: ada_launch, uri: 'https://github.com/personalrobotics/ada_launch.git', version: 'master'}
 - git: {local-name: aikido, uri: 'https://github.com/personalrobotics/aikido.git', version: 'master'}
-- git: {local-name: bite_selection_package, uri: 'https://github.com/personalrobotics/bite_selection_package.git', version: 'demo/summer2019'}
+- git: {local-name: bite_selection_package, uri: 'https://github.com/personalrobotics/bite_selection_package.git', version: 'master'}
 - git: {local-name: face_detection, uri: 'https://github.com/personalrobotics/face_detection.git', version: 'master'}
-- git: {local-name: food_detector, uri: 'https://github.com/personalrobotics/food_detector.git', version: 'demo/summer2019'}
+- git: {local-name: food_detector, uri: 'https://github.com/personalrobotics/food_detector.git', version: 'master'}
 - git: {local-name: forque_sensor_hardware, uri: 'https://github.com/personalrobotics/forque_sensor_hardware.git', version: 'master'}
 - git: {local-name: jaco_hardware, uri: 'https://github.com/personalrobotics/jaco_hardware.git', version: 'master'}
 - git: {local-name: libada, uri: 'https://github.com/personalrobotics/libada.git', version: 'master'}

--- a/ada-feeding.rosinstall
+++ b/ada-feeding.rosinstall
@@ -9,10 +9,10 @@
 - git: {local-name: jaco_hardware, uri: 'https://github.com/personalrobotics/jaco_hardware.git', version: 'master'}
 - git: {local-name: libada, uri: 'https://github.com/personalrobotics/libada.git', version: 'master'}
 - git: {local-name: net-ft-ros, uri: 'https://github.com/personalrobotics/net-ft-ros.git', version: 'master'}
-- git: {local-name: pose_estimators, uri: 'https://github.com/personalrobotics/pose_estimators.git', version: 'demo/summer2019'}
+- git: {local-name: pose_estimators, uri: 'https://github.com/personalrobotics/pose_estimators.git', version: 'master'}
 - git: {local-name: pr_assets, uri: 'https://github.com/personalrobotics/pr_assets.git', version: 'master'}
 - git: {local-name: pr_control_msgs, uri: 'https://github.com/personalrobotics/pr_control_msgs.git', version: 'master'}
 - git: {local-name: pr_hardware_interfaces, uri: 'https://github.com/personalrobotics/pr_hardware_interfaces.git', version: 'master'}
 - git: {local-name: pr_tsr, uri: 'https://github.com/personalrobotics/pr_tsr.git', version: 'master'}
 - git: {local-name: pytorch_retinanet, uri: 'https://github.com/personalrobotics/pytorch_retinanet.git', version: 'master'}
-- git: {local-name: rewd_controllers, uri: 'https://github.com/personalrobotics/rewd_controllers.git', version: 'ada_demo/summer2019'}
+- git: {local-name: rewd_controllers, uri: 'https://github.com/personalrobotics/rewd_controllers.git', version: 'master'}


### PR DESCRIPTION
On multiple branches, summer 2019 demo branches were merged into master, resulting in the rosinstall breaking. Fixed that my setting the version of those branches to 'master'.